### PR TITLE
Fix oversimplification in README.md's cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Simple rules to remember:
 
 - if your key includes a JSON control character like `{}[],:` or space, use quotes
 - if your string starts with `{` or `[`, use quotes
-- remember that quoteless strings include everything up to the end of the line.
+- remember that quoteless strings include everything up to the end of the line, excluding trailing whitespace.
+- remember that quoteless strings include everything up to the end of the line and preceding whitespace.
 
 #### Details
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Simple rules to remember:
 - if your key includes a JSON control character like `{}[],:` or space, use quotes
 - if your string starts with `{` or `[`, use quotes
 - remember that quoteless strings include everything up to the end of the line, excluding trailing whitespace.
-- remember that quoteless strings include everything up to the end of the line and preceding whitespace.
 
 #### Details
 


### PR DESCRIPTION
@pcarrier and I disagree as to the best phrasing. Leaving both options in this diff.

Regardless, the concern is that the later claim that "When you omit quotes the string ends at the newline. Preceding and trailing whitespace is ignored as are escapes." conflicts with the claim under "Simple rules to remember".

Let me know which and I'll update the PR.